### PR TITLE
Update github-action to v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,13 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Install dependencies
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@v5
         with:
           # just perform install
           runTests: false
       - run: yarn lint
       - name: Run e2e tests
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@v5
         with:
           # we have already installed all dependencies above
           install: false


### PR DESCRIPTION
This PR resolves issue https://github.com/bahmutov/cypress-gh-action-monorepo/issues/44 "Workflow failure test.yml".

It updates the version of github-action to v5, which is the latest version available. (See [github-action/releases](https://github.com/cypress-io/github-action/releases).)


